### PR TITLE
Do not become root when pulling the archive from S3

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,7 @@
     object: "{{ oracle_java_archive_filename }}"
     dest: /tmp/{{ oracle_java_archive_filename }}
     mode: get
+  become: no
   delegate_to: localhost
   # This task will run even if a local copy of the file already
   # exists, so we need this next line for idempotence


### PR DESCRIPTION
Otherwise boto3 cannot find your AWS creds when running via packer, since it's not looking in your home directory!

How soon I forget the lessons of the past. :disappointed: 